### PR TITLE
Add exponent parameter

### DIFF
--- a/crate-wasm/src/lib.rs
+++ b/crate-wasm/src/lib.rs
@@ -10,19 +10,6 @@ use std::f64::consts;
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
-fn in_cardioid(x: f64, y: f64) -> bool {
-    let a = x - 1.0 / 4.0;
-    let q = a * a + y * y;
-
-    q * (q + a) <= 0.25 * y * y
-}
-
-fn in_bulb(x: f64, y: f64) -> bool {
-    let a = x + 1.0;
-
-    a * a + y * y <= 0.0625 // <= 1/16
-}
-
 // how many iterations does it take to escape?
 fn get_escape_time(
     x: f64,
@@ -30,18 +17,17 @@ fn get_escape_time(
     max_iterations: u32,
     escape_radius: f64,
     is_smoothed: bool,
+    exponent: u32
 ) -> (u32, f64) {
-    if in_cardioid(x, y) || in_bulb(x, y) {
-        return (max_iterations, 0.0);
-    }
-
     let c: Complex64 = Complex64::new(x, y);
     let mut z: Complex64 = c.clone();
+    let e: Complex64 = Complex64::new(exponent.into(),0.0);
+
 
     let mut iter: u32 = 0;
     while z.norm() < escape_radius && iter < max_iterations {
         iter += 1;
-        z = z * z + c;
+        z = z.powc(e) + c;
     }
 
     // https://stackoverflow.com/questions/369438/smooth-spectrum-for-mandelbrot-set-rendering
@@ -69,6 +55,7 @@ fn generate_image(
     z: f64,
     max_iterations: u32,
     is_smoothed: bool,
+    exponent: u32
 ) -> [u8; 256 * 256 * 4] {
     // size of leaflet tile
     let size: u32 = 256;
@@ -91,7 +78,7 @@ fn generate_image(
     for (x, im) in im_range {
         for (y, re) in re_range.clone() {
             let (escape_time, smoothed_value) =
-                get_escape_time(re, im, max_iterations, escape_radius, is_smoothed);
+                get_escape_time(re, im, max_iterations, escape_radius, is_smoothed, exponent);
 
             let pixel: [u8; 3] = if escape_time == max_iterations {
                 black
@@ -126,13 +113,14 @@ fn generate_image(
 }
 
 #[wasm_bindgen]
-pub fn get_tile(x: u32, y: u32, z: u32, max_iterations: u32, is_smoothed: bool) -> Vec<u8> {
+pub fn get_tile(x: u32, y: u32, z: u32, max_iterations: u32, is_smoothed: bool, exponent: u32) -> Vec<u8> {
     let image_data = generate_image(
         x as f64,
         y as f64,
         (z as f64) - 2.0, // increase leaflet viewport
         max_iterations,
         is_smoothed,
+        exponent,
     );
 
     image_data.to_vec()

--- a/crate-wasm/src/lib.rs
+++ b/crate-wasm/src/lib.rs
@@ -21,13 +21,11 @@ fn get_escape_time(
 ) -> (u32, f64) {
     let c: Complex64 = Complex64::new(x, y);
     let mut z: Complex64 = c.clone();
-    let e: Complex64 = Complex64::new(exponent.into(),0.0);
-
 
     let mut iter: u32 = 0;
     while z.norm() < escape_radius && iter < max_iterations {
         iter += 1;
-        z = z.powc(e) + c;
+        z = z.powu(exponent) + c;
     }
 
     // https://stackoverflow.com/questions/369438/smooth-spectrum-for-mandelbrot-set-rendering

--- a/www/app/main.ts
+++ b/www/app/main.ts
@@ -5,7 +5,7 @@ import * as L from "leaflet";
 interface WorkerContainer { worker: Worker, activeJobs: Array<string>, ready: boolean }
 let workers: Array<WorkerContainer> = [];
 const initNumWorkers = Math.min(navigator.hardwareConcurrency || 4, 60);
-let maxIterations = 200, isSmoothed = true, numWorkers = initNumWorkers;
+let maxIterations = 200, exponent = 5, isSmoothed = true, numWorkers = initNumWorkers;
 
 function createWorker() {
   const w: WorkerContainer = { worker: new Worker("./worker.js"), activeJobs: [], ready: false };
@@ -43,6 +43,18 @@ function handleInputs(map: L.Map) {
     }
     iterationsInput.value = String(parsedValue);
     maxIterations = parsedValue;
+    refreshMap(map);
+  }, 1000);
+  
+  const exponentInput = <HTMLInputElement>document.getElementById("exponent");
+  exponentInput.value = String(exponent);
+  exponentInput.oninput = debounce(({ target }) => {
+    let parsedValue = parseInt((<HTMLInputElement>target).value, 10);
+    if (isNaN(parsedValue) || parsedValue < 1) {
+      parsedValue = 2;
+    }
+    exponentInput.value = String(parsedValue);
+    exponent = parsedValue;
     refreshMap(map);
   }, 1000);
 
@@ -90,7 +102,7 @@ function createTile(coords: L.Coords, done: Function) {
     }
   };
   selectedWorker.worker.addEventListener("message", tileRetrievedHandler);
-  selectedWorker.worker.postMessage({ coords, maxIterations, isSmoothed });
+  selectedWorker.worker.postMessage({ coords, maxIterations, exponent, isSmoothed });
   return tile;
 }
 

--- a/www/app/main.ts
+++ b/www/app/main.ts
@@ -5,7 +5,7 @@ import * as L from "leaflet";
 interface WorkerContainer { worker: Worker, activeJobs: Array<string>, ready: boolean }
 let workers: Array<WorkerContainer> = [];
 const initNumWorkers = Math.min(navigator.hardwareConcurrency || 4, 60);
-let maxIterations = 200, exponent = 5, isSmoothed = true, numWorkers = initNumWorkers;
+let maxIterations = 200, exponent = 2, isSmoothed = true, numWorkers = initNumWorkers;
 
 function createWorker() {
   const w: WorkerContainer = { worker: new Worker("./worker.js"), activeJobs: [], ready: false };
@@ -50,7 +50,7 @@ function handleInputs(map: L.Map) {
   exponentInput.value = String(exponent);
   exponentInput.oninput = debounce(({ target }) => {
     let parsedValue = parseInt((<HTMLInputElement>target).value, 10);
-    if (isNaN(parsedValue) || parsedValue < 1) {
+    if (isNaN(parsedValue) || parsedValue < 2) {
       parsedValue = 2;
     }
     exponentInput.value = String(parsedValue);

--- a/www/index.html
+++ b/www/index.html
@@ -48,6 +48,10 @@
       <input type="number" id="iterations" name="iterations" min="10" max="100000" step="10">
     </div>
     <div class="numberInputWrapper">
+      <label for="exponent">Exponent:</label>
+      <input type="number" id="exponent" name="exponent" min="1" max="24" step="1">
+    </div>
+    <div class="numberInputWrapper">
       <label for="workers">Workers:</label>
       <input type="number" id="workers" name="workers" min="1" max="20" step="1">
     </div>

--- a/www/worker/worker.js
+++ b/www/worker/worker.js
@@ -2,8 +2,8 @@ import("../../crate-wasm/pkg").then(wasm => {
   wasm.init();
   self.addEventListener("message", ev => {
     try {
-      const { coords, maxIterations, isSmoothed } = ev.data;
-      const data = wasm.get_tile(coords.x, coords.y, coords.z, maxIterations, isSmoothed);
+      const { coords, maxIterations, isSmoothed, exponent } = ev.data;
+      const data = wasm.get_tile(coords.x, coords.y, coords.z, maxIterations, isSmoothed, exponent);
       self.postMessage({ coords: JSON.stringify(coords), pixels: data });
     } catch (err) {
       console.log(err);


### PR DESCRIPTION
Adds an additional parameter ("exponent") to the UI, which governs the exponent on the primary recurrence relation
 
Note:
- Since we can't predict easily where the cardiod/bulb will live (or at least it's not obvious to me!) we have to remove the optimizations around those or else there are odd artifacts when they don't match, i.e. at higher exponents than 2..

<img width="1234" alt="Screen Shot 2021-02-20 at 10 43 00 PM" src="https://user-images.githubusercontent.com/122646/108614934-fec86280-73cc-11eb-9ea2-c8d85ae30f5b.png">
